### PR TITLE
Modified the include path logic

### DIFF
--- a/platformio/builder/tools/piointegration.py
+++ b/platformio/builder/tools/piointegration.py
@@ -15,6 +15,8 @@
 import glob
 import os
 
+import click
+
 import SCons.Defaults  # pylint: disable=import-error
 import SCons.Subst  # pylint: disable=import-error
 from SCons.Script import COMMAND_LINE_TARGETS  # pylint: disable=import-error
@@ -22,11 +24,20 @@ from SCons.Script import COMMAND_LINE_TARGETS  # pylint: disable=import-error
 from platformio.proc import exec_command, where_is_program
 from platformio.debug_const import DEBUG
 
+@click.option(
+    "--spine-dir",
+    "-sl",
+    default=None,
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, writable=True),
+)
 def IsIntegrationDump(_):
     if DEBUG == 1:
         print("Debug: Entering - builder - tools - piointegration - IsIntegrationDump \n\n")
     return set(["__idedata", "idedata"]) & set(COMMAND_LINE_TARGETS)
 
+def get_spine_location(spine_dir):
+    spine_location = os.path.abspath(spine_dir) if spine_dir else os.path.expanduser("~") + "/.platformio/packages/framework-innetra/"
+    return spine_location
 
 def DumpIntegrationIncludes(env):
     if DEBUG == 1:
@@ -58,7 +69,9 @@ def DumpIntegrationIncludes(env):
         ]
         for g in toolchain_incglobs:
             result["toolchain"].extend([os.path.abspath(inc) for inc in glob.glob(g)])
-
+    spine_location = get_spine_location(env.get('spine_dir'))
+    if spine_location:
+            result["build"].append(os.path.abspath(spine_location + '/include'))
     return result
 
 

--- a/platformio/project/commands/init.py
+++ b/platformio/project/commands/init.py
@@ -96,7 +96,7 @@ def project_init_cmd(
 
     with fs.cd(project_dir):
         if environment:
-            update_project_env(environment, boards, spine_location, project_options,)
+            update_project_env(environment, project_options)
         elif boards:
             update_board_envs(project_dir, boards, project_options, env_prefix)
 
@@ -508,7 +508,7 @@ def update_board_envs(project_dir, boards, extra_project_options, env_prefix):
         config.save()
 
 
-def update_project_env(environment, boards, spine_location ,extra_project_options=None):
+def update_project_env(environment, extra_project_options=None):
     if not extra_project_options:
         return
     env_section = "env:%s" % environment
@@ -527,8 +527,6 @@ def update_project_env(environment, boards, spine_location ,extra_project_option
     config = ProjectConfig(
         "platformio.ini", parse_extra=False, expand_interpolations=False
     )
-    if boards == 'innetra':
-        config.set("platformio", "include_dir", spine_location + "/include")
     for section, options in option_to_sections.items():
         if not options:
             continue


### PR DESCRIPTION
Removed the old logic where we calculate the include path in the init.py file. 
Added include path logic in the piointegration.py file under function DumpIntegrationIncludes() which configures all the include path before project creation.